### PR TITLE
WIP:: Add routine to get count of ULT from abt-io pool

### DIFF
--- a/include/abt-io.h
+++ b/include/abt-io.h
@@ -218,6 +218,11 @@ int abt_io_op_wait(abt_io_op_t* op);
  */
 void abt_io_op_free(abt_io_op_t* op);
 
+/**
+ * enquire about status of underlying Argobots pool
+ */
+size_t abt_io_get_pool_size(abt_io_instance_id aid);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/abt-io.c
+++ b/src/abt-io.c
@@ -1021,3 +1021,14 @@ void abt_io_op_free(abt_io_op_t* op)
     op->free_fn(op->state);
     free(op);
 }
+
+size_t abt_io_get_pool_size(abt_io_instance_id aid)
+{
+    size_t size;
+    int ret;
+    ret = ABT_pool_get_size(aid->progress_pool, &size);
+    if (ret == ABT_SUCCESS)
+        return size;
+    else
+        return -1;
+}


### PR DESCRIPTION
In GitLab by @roblatham00 on Apr 13, 2020, 14:43

goal: determine how many outstanding operations are sitting in the abt-io Argobots pool. 
approach: a dumb ol' accessor function to call `ABT_pool_get_size` on my behalf

considerations: This routine would be the first "ABT utility" routine.  Would not want to set a bad design precedent