### PR TITLE
strip /json-c component out of json-c include path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,13 @@ CFLAGS="$ARGOBOTS_CFLAGS $CFLAGS"
 PKG_CHECK_MODULES([JSONC],[json-c],[],
    [AC_MSG_ERROR([Could not find working json-c installation!])])
 LIBS="$JSONC_LIBS $LIBS"
+dnl
+dnl Note that pkg-config may report an include path that contains a
+dnl "/json-c" component.  If so, strip it out.  We prefer to use an explicit
+dnl subdir path in the source to to avoid potential header name conflicts
+dnl with other json libraries.
+dnl
+JSONC_CFLAGS=`echo $JSONC_CFLAGS | sed 's/\/include\/json-c/\/include/g'`
 CPPFLAGS="$JSONC_CFLAGS $CPPFLAGS"
 CFLAGS="$JSONC_CFLAGS $CFLAGS"
 


### PR DESCRIPTION
The source code includes json-c headers using `#include <json-c/json.h>`, which is probably a good idea to avoid conflicts with other packages that may provide a json.h file.  The json-c pkgconfig file reports an include path that already contains an include/json-c component, however, which will make the `#include` fail if the build relies exclusively on pkg-config paths.

This PR strips out the extra path component in the autoconf script to avoid this problem.