### PR TITLE
[WIP] liburing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,12 @@ directly, it will block forward progress for all threads on that execution
 stream until that blocking I/O system call completes.
 
 The abt-io library addresses this problem by providing a set of wrapper
-functions that delegate blocking I/O system calls to a dedicated set
-of execution streams (i.e. pthreads) that perform the I/O operation on
-behalf of the caller.  User level threads that invoke these wrappers
-will yield control until the I/O operation completes, allowing other
-user-level threads to continue execution.
-
-If multiple I/O operations are issued at the same time, then they will make
-progress concurrently according to the number of execution streams assigned
-to abt-io.
+functions that delegate blocking I/O system calls to a separate I/O engine
+to execute. User level threads that invoke these wrappers will yield control
+until the I/O operation completes, allowing other user-level threads to
+continue execution.  If multiple I/O operations are issued at the same time,
+then they will make progress concurrently according to the number of
+ 
 
 This library is a companion to the Margo library (which provides similar
 capability, but for the Mercury RPC library).  When used with Margo it
@@ -30,12 +27,16 @@ Margo: https://github.com/mochi-hpc/mochi-margo
 ##  Dependencies
 
 * argobots (https://github.com/pmodels/argobots)
+* [optional] liburing (TODO)
 
 ## Building Argobots (dependency)
 
 Example configuration:
 
     ../configure --prefix=/home/pcarns/working/install
+
+Add `--enable-liburing` to build in optional support for the liburing I/O
+engine.
 
 ## Building
 
@@ -45,16 +46,16 @@ Example configuration:
         PKG_CONFIG_PATH=/home/pcarns/working/install/lib/pkgconfig \
         CFLAGS="-g -Wall"
 
-## Design details
+## Design details: posix engine
 
 ![abt-io architecture](doc/fig/abt-io-diagram.png)
 
-abt-io provides Argobots-aware wrappers to common POSIX I/O functions
-like open(), pwrite(), and close().  The wrappers behave identically to
-their POSIX counterparts from a caller's point of view, but internally
-they delegate blocking I/O system calls to a dedicated Argobots pool.
-The caller is suspended until the system call completes so that other
-concurrent ULTs can make progress in the mean time.
+The default engine used by abt-io is called "posix".  When this engine is
+used, the abt-io wrappers behave identically to their POSIX counterparts
+from a caller's point of view, but internally they delegate blocking I/O
+system calls to a dedicated Argobots pool.  The caller is suspended until
+the system call completes so that other concurrent ULTs can make progress in
+the mean time.
 
 The delegation step is implemented by spawning a new tasklet that
 coordinates with the calling ULT via an eventual construct. The tasklets
@@ -74,7 +75,23 @@ simpler interface and less serialization.
 Additional details and performance analysis can be found in
 https://ieeexplore.ieee.org/document/8082139.
 
+## Design details: liburing engine
+
+The optional liburing engine requires compile-time support (activated with the
+`--enable-liburing` configure option) plus a runtime json configuration
+option to activate (`{"engine"="posix"}`).  In this mode, operations
+supported by the liburing engine (presently just `abt_io_pread()` and
+`abt_io_pwrite()`) will bypass the tasklet delegation described in the posix
+engine design and instead submit an operation directly into liburing.  A
+dedicated ULT in the abt-io pool blocks on `io_uring_wait_cqe()` to harvest
+completed operations and signal the eventual corresponding to each
+operation.
+
+This engine is identical to the posix engine in terms of functionality, but
+may offer performance advantages on some systems.
+
 ## Tracing
+
 If you enable tracing, either by setting the ` "trace_io":true,` in the json
 config, or by setting the environment variable `ABT_IO_TRACE_IO`, abt-io will log
 to stderr the i/o operations it is doing in Darshan "DXT format": for example

--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,7 @@ AC_MSG_RESULT(no))
 # zlib is used for benchmark output file
 CHECK_ZLIB
 
+build_liburing=no
 AC_ARG_ENABLE(liburing,
         [AS_HELP_STRING([--enable-liburing],[Enable liburing library support @<:@default=no@:>@])],
         [case "${enableval}" in
@@ -127,10 +128,12 @@ if test "$enable_liburing" = "yes"; then
         CPPFLAGS="$LIBURING_CFLAGS $CPPFLAGS"
         CFLAGS="$LIBURING_CFLAGS $CFLAGS"
         LIBS="$LIBURING_LIBS $LIBS"
+        build_liburing=yes
 else
         USE_LIBURING=0
 fi
 AC_SUBST(USE_LIBURING)
+AM_CONDITIONAL([BUILD_LIBURING], [test "x${build_liburing}" = xyes])
 
 AC_CONFIG_FILES([Makefile maint/abt-io.pc])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -130,15 +130,15 @@ if test "$enable_liburing" = "yes"; then
         LIBS="$LIBURING_LIBS $LIBS"
         build_liburing=yes
 
-        # see if this system also has IOSQE_ASYNC_BIT
-        AC_MSG_CHECKING([for IOSQE_ASYNC_BIT])
+        # see if this system also has IOSQE_ASYNC
+        AC_MSG_CHECKING([for IOSQE_ASYNC])
         AC_TRY_COMPILE([
         #include <liburing.h>
         ], [
-        int flag = IOSQE_ASYNC_BIT;
+        int flag = IOSQE_ASYNC;
         ],
         AC_MSG_RESULT(yes)
-        AC_DEFINE([HAVE_IOSQE_ASYNC_BIT], [], [Define if IOSQE_ASYNC_BIT is present])
+        AC_DEFINE([HAVE_IOSQE_ASYNC], [], [Define if IOSQE_ASYNC is present])
         ,
         AC_MSG_RESULT(no))
 else

--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,18 @@ if test "$enable_liburing" = "yes"; then
         CFLAGS="$LIBURING_CFLAGS $CFLAGS"
         LIBS="$LIBURING_LIBS $LIBS"
         build_liburing=yes
+
+        # see if this system also has IOSQE_ASYNC_BIT
+        AC_MSG_CHECKING([for IOSQE_ASYNC_BIT])
+        AC_TRY_COMPILE([
+        #include <liburing.h>
+        ], [
+        int flag = IOSQE_ASYNC_BIT;
+        ],
+        AC_MSG_RESULT(yes)
+        AC_DEFINE([HAVE_IOSQE_ASYNC_BIT], [], [Define if IOSQE_ASYNC_BIT is present])
+        ,
+        AC_MSG_RESULT(no))
 else
         USE_LIBURING=0
 fi
@@ -137,7 +149,7 @@ AM_CONDITIONAL([BUILD_LIBURING], [test "x${build_liburing}" = xyes])
 
 AC_CONFIG_FILES([Makefile maint/abt-io.pc])
 AC_OUTPUT
- 
+
 if test "x$NONCOMPLIANT_IO" = "x1" ; then
     AC_MSG_WARN([This platform lacks O_DIRECT and/or mkostemp().  All code
     should still compile and pass make check tests, but behavior and

--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,28 @@ AC_MSG_RESULT(no))
 # zlib is used for benchmark output file
 CHECK_ZLIB
 
+AC_ARG_ENABLE(liburing,
+        [AS_HELP_STRING([--enable-liburing],[Enable liburing library support @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_liburing="yes" ;;
+         no) enable_liburing="no" ;;
+         *) AC_MSG_ERROR(bad value ${enableval} for --enable-liburing) ;;
+ esac],
+ [enable_liburing="no"]
+ )
+AM_CONDITIONAL(ENABLE_LIBURING, test x$enable_liburing = xyes)
+if test "$enable_liburing" = "yes"; then
+        PKG_CHECK_MODULES(LIBURING, liburing)
+        AC_DEFINE(USE_LIBURING, 1, [LIBURING support enabled.])
+        USE_LIBURING=1
+        CPPFLAGS="$LIBURING_CFLAGS $CPPFLAGS"
+        CFLAGS="$LIBURING_CFLAGS $CFLAGS"
+        LIBS="$LIBURING_LIBS $LIBS"
+else
+        USE_LIBURING=0
+fi
+AC_SUBST(USE_LIBURING)
+
 AC_CONFIG_FILES([Makefile maint/abt-io.pc])
 AC_OUTPUT
  

--- a/src/abt-io-macros.h
+++ b/src/abt-io-macros.h
@@ -117,4 +117,20 @@ static const int json_type_int64 = json_type_int;
          && (__element = json_object_array_get_idx(__array, __index)); \
          __index++)
 
+// Checks if the provided JSON string is one of the provided string arguments.
+// Prints an error and returns -1 if it does not match any.
+#define CONFIG_IS_IN_ENUM_STRING(__config, __field_name, ...)          \
+    do {                                                               \
+        unsigned    _i      = 0;                                       \
+        const char* _vals[] = {__VA_ARGS__, NULL};                     \
+        while (_vals[_i]                                               \
+               && strcmp(_vals[_i], json_object_get_string(__config))) \
+            _i++;                                                      \
+        if (!_vals[_i]) {                                              \
+            fprintf(stderr, "Invalid enum value for %s (\"%s\")",      \
+                    __field_name, json_object_get_string(__config));   \
+            return (-1);                                               \
+        }                                                              \
+    } while (0)
+
 #endif /* __ABT_IO_MACROS */

--- a/src/abt-io.c
+++ b/src/abt-io.c
@@ -59,7 +59,23 @@ struct abt_io_op {
     struct iovec vec;
 };
 
+#ifdef USE_LIBURING
 static void uring_completion_task_fn(void* foo);
+static int  issue_pwrite_liburing(abt_io_instance_id aid,
+                                  abt_io_op_t*       op,
+                                  int                fd,
+                                  const void*        buf,
+                                  size_t             count,
+                                  off_t              offset,
+                                  ssize_t*           ret);
+static int  issue_pread_liburing(abt_io_instance_id aid,
+                                 abt_io_op_t*       op,
+                                 int                fd,
+                                 void*              buf,
+                                 size_t             count,
+                                 off_t              offset,
+                                 ssize_t*           ret);
+#endif /* USE_LIBURING */
 
 /**
  * Validates the format of the configuration and fills default values
@@ -75,13 +91,7 @@ static int issue_pwrite_posix(abt_io_instance_id aid,
                               size_t             count,
                               off_t              offset,
                               ssize_t*           ret);
-static int issue_pwrite_liburing(abt_io_instance_id aid,
-                                 abt_io_op_t*       op,
-                                 int                fd,
-                                 const void*        buf,
-                                 size_t             count,
-                                 off_t              offset,
-                                 ssize_t*           ret);
+
 static int (*issue_pwrite)(
     abt_io_instance_id, abt_io_op_t*, int, const void*, size_t, off_t, ssize_t*)
     = issue_pwrite_posix;
@@ -93,13 +103,6 @@ static int issue_pread_posix(abt_io_instance_id aid,
                              size_t             count,
                              off_t              offset,
                              ssize_t*           ret);
-static int issue_pread_liburing(abt_io_instance_id aid,
-                                abt_io_op_t*       op,
-                                int                fd,
-                                void*              buf,
-                                size_t             count,
-                                off_t              offset,
-                                ssize_t*           ret);
 static int (*issue_pread)(
     abt_io_instance_id, abt_io_op_t*, int, void*, size_t, off_t, ssize_t*)
     = issue_pread_posix;
@@ -705,6 +708,7 @@ static void abt_io_pwrite_fn(void* foo)
     return;
 }
 
+#ifdef USE_LIBURING
 static int issue_pwrite_liburing(abt_io_instance_id aid,
                                  abt_io_op_t*       arg_op,
                                  int                fd,
@@ -762,6 +766,7 @@ err:
     if (op->e != NULL) ABT_eventual_free(&op->e);
     return -1;
 }
+#endif /* USE_LIBURING */
 
 static int issue_pwrite_posix(abt_io_instance_id aid,
                               abt_io_op_t*       op,
@@ -2025,6 +2030,7 @@ static void teardown_pool(abt_io_instance_id aid)
     return;
 }
 
+#ifdef USE_LIBURING
 static int issue_pread_liburing(abt_io_instance_id aid,
                                 abt_io_op_t*       arg_op,
                                 int                fd,
@@ -2082,3 +2088,4 @@ err:
     if (op->e != NULL) ABT_eventual_free(&op->e);
     return -1;
 }
+#endif /* USE_LIBURING */

--- a/src/abt-io.c
+++ b/src/abt-io.c
@@ -211,7 +211,17 @@ void abt_io_finalize(abt_io_instance_id aid)
 #ifdef USE_LIBURING
     if (aid->engine_type == ABT_IO_ENGINE_LIBURING) {
         /* stop the persistent completion queue fn */
-        aid->uring_shutdown_flag = 1;
+        /* We set a shutdown flag so that the engine loop will see that we
+         * are in shutdown mode.  Then submit a timeout operation to fire
+         * immediately to break out of the cqe wait function.
+         */
+        struct __kernel_timespec ts  = {0};
+        struct io_uring_sqe*     sqe = io_uring_get_sqe(&aid->ring);
+        aid->uring_shutdown_flag     = 1;
+        io_uring_prep_timeout(sqe, &ts, 0, 0);
+        /* NULL user data to indicate progress loop should ignore content */
+        io_uring_sqe_set_data(sqe, NULL);
+        io_uring_submit(&aid->ring);
         ABT_task_join(aid->uring_completion_task);
 
         /* tear down uring queues */
@@ -257,7 +267,11 @@ static void uring_completion_task_fn(void* foo)
          */
         ret = io_uring_wait_cqe(&aid->ring, &cqe);
         if (ret == 0) {
-            fprintf(stderr, "DBG: got cqe.\n");
+            if (!cqe->user_data) {
+                fprintf(stderr, "DBG: got cqe timeout break.\n");
+            } else {
+                fprintf(stderr, "DBG: got cqe (unknown).\n");
+            }
             io_uring_cqe_seen(&aid->ring, cqe);
         }
     }

--- a/src/abt-io.c
+++ b/src/abt-io.c
@@ -107,6 +107,10 @@ abt_io_instance_id abt_io_init_ext(const struct abt_io_init_info* uargs)
     }
 
     /* validate and complete configuration */
+    /* TODO: if liburing is enabled; validate that pool only has one ES (if
+     * possible); it won't be helpful to have more than one dedicated to
+     * abt-io in that case.
+     */
     ret = validate_and_complete_config(config, args.progress_pool);
     if (ret != 0) {
         fprintf(stderr, "Could not validate and complete configuration");
@@ -1627,6 +1631,17 @@ static int validate_and_complete_config(struct json_object* _config,
      *       "num_xstreams": 4
      *    }
      * }
+     *
+     * control over io engine type
+     * --------------
+     * Then engine field can be set to control what I/O engine will be used
+     * to execute operations.  The current options are:
+     * - "posix" - the default option; uses conventional open, close, pwrite,
+     *    etc. functions executed within a dedicated Argobots pool
+     * - "liburing" - uses the Linux specifc liburing library
+     *
+     * example:
+     * {"engine"="posix"}
      */
 
     /* report version number for this component */
@@ -1706,6 +1721,14 @@ static int validate_and_complete_config(struct json_object* _config,
                                "internal_pool.kind", 1);
         CONFIG_OVERRIDE_STRING(_internal_pool, "access", "mpmc",
                                "internal_pool.kind", 1);
+    }
+
+    /* I/O engine type */
+    if (!CONFIG_HAS(_config, "engine", val)) {
+        CONFIG_OVERRIDE_STRING(_config, "engine", "posix", "engine", 0);
+    } else {
+        struct json_object* jengine = json_object_object_get(_config, "engine");
+        CONFIG_IS_IN_ENUM_STRING(jengine, "engine", "posix", "liburing");
     }
 
     return (0);

--- a/src/abt-io.c
+++ b/src/abt-io.c
@@ -67,6 +67,24 @@ static void uring_completion_task_fn(void* foo);
 static int validate_and_complete_config(struct json_object* _config,
                                         ABT_pool            _progress_pool);
 
+static int issue_pwrite_posix(abt_io_instance_id aid,
+                              abt_io_op_t*       op,
+                              int                fd,
+                              const void*        buf,
+                              size_t             count,
+                              off_t              offset,
+                              ssize_t*           ret);
+static int issue_pwrite_liburing(abt_io_instance_id aid,
+                                 abt_io_op_t*       op,
+                                 int                fd,
+                                 const void*        buf,
+                                 size_t             count,
+                                 off_t              offset,
+                                 ssize_t*           ret);
+static int (*issue_pwrite)(
+    abt_io_instance_id, abt_io_op_t*, int, const void*, size_t, off_t, ssize_t*)
+    = issue_pwrite_posix;
+
 /**
  * Set up pool (creating if needed) for abt-io instance to use
  */
@@ -128,6 +146,8 @@ abt_io_instance_id abt_io_init_ext(const struct abt_io_init_info* uargs)
     /* TODO: if liburing is enabled; validate that pool only has one ES (if
      * possible); it won't be helpful to have more than one dedicated to
      * abt-io in that case.
+     * NOTE: maybe 2 ESs? We may want one to run posix operations that
+     * aren't directly supported by liburing.
      */
     ret = validate_and_complete_config(config, args.progress_pool);
     if (ret != 0) {
@@ -184,6 +204,9 @@ abt_io_instance_id abt_io_init_ext(const struct abt_io_init_info* uargs)
                 "Error: unable to create uring_completion_task_fn() task.\n");
             goto error;
         }
+
+        /* set function pointers for operations supported by liburing */
+        issue_pwrite = issue_pwrite_liburing;
 #endif
     }
 
@@ -259,6 +282,7 @@ static void uring_completion_task_fn(void* foo)
     struct abt_io_instance* aid = foo;
     int                     ret;
     struct io_uring_cqe*    cqe;
+    struct abt_io_op*       op;
 
     while (!aid->uring_shutdown_flag) {
         /* NOTE: we intentionally do not user a timeout here.  If we need
@@ -271,6 +295,11 @@ static void uring_completion_task_fn(void* foo)
                 fprintf(stderr, "DBG: got cqe timeout break.\n");
             } else {
                 fprintf(stderr, "DBG: got cqe (unknown).\n");
+                op = (struct abt_io_op*)cqe->user_data;
+                /* TODO: check for any type problems on supported ops */
+                int64_t* result = op->state;
+                *result         = cqe->res;
+                ABT_eventual_set(op->e, NULL, 0);
             }
             io_uring_cqe_seen(&aid->ring, cqe);
         }
@@ -654,13 +683,60 @@ static void abt_io_pwrite_fn(void* foo)
     return;
 }
 
-static int issue_pwrite(abt_io_instance_id aid,
-                        abt_io_op_t*       op,
-                        int                fd,
-                        const void*        buf,
-                        size_t             count,
-                        off_t              offset,
-                        ssize_t*           ret)
+static int issue_pwrite_liburing(abt_io_instance_id aid,
+                                 abt_io_op_t*       arg_op,
+                                 int                fd,
+                                 const void*        buf,
+                                 size_t             count,
+                                 off_t              offset,
+                                 ssize_t*           ret)
+{
+    int                  rc;
+    struct io_uring_sqe* sqe      = io_uring_get_sqe(&aid->ring);
+    struct abt_io_op     stack_op = {0};
+    struct abt_io_op*    op;
+
+    if (arg_op == NULL)
+        op = &stack_op;
+    else
+        op = arg_op;
+
+    rc = ABT_eventual_create(0, &op->e);
+    if (rc != ABT_SUCCESS) {
+        *ret = -ENOMEM;
+        goto err;
+    }
+    op->state = ret;
+
+    io_uring_prep_write(sqe, fd, buf, count, offset);
+    io_uring_sqe_set_data(sqe, op);
+    io_uring_submit(&aid->ring);
+
+    if (arg_op == NULL) {
+        rc = ABT_eventual_wait(op->e, NULL);
+        // what error should we use here?
+        if (rc != ABT_SUCCESS) {
+            *ret = -EINVAL;
+            goto err;
+        }
+    } else {
+        op->free_fn = free;
+    }
+
+    if (arg_op == NULL) ABT_eventual_free(&op->e);
+    return 0;
+err:
+    if (op->e != NULL) ABT_eventual_free(&op->e);
+    return -1;
+}
+
+static int issue_pwrite_posix(abt_io_instance_id aid,
+                              abt_io_op_t*       op,
+                              int                fd,
+                              const void*        buf,
+                              size_t             count,
+                              off_t              offset,
+                              ssize_t*           ret)
 {
     struct abt_io_pwrite_state  state;
     struct abt_io_pwrite_state* pstate = NULL;

--- a/src/abt-io.c
+++ b/src/abt-io.c
@@ -708,6 +708,7 @@ static int issue_pwrite_liburing(abt_io_instance_id aid,
     }
     op->state = ret;
 
+    /* TODO: abt_io_log() support for uring operations */
     io_uring_prep_write(sqe, fd, buf, count, offset);
     io_uring_sqe_set_data(sqe, op);
     io_uring_submit(&aid->ring);

--- a/src/abt-io.c
+++ b/src/abt-io.c
@@ -135,7 +135,7 @@ abt_io_instance_id abt_io_init_ext(const struct abt_io_init_info* uargs)
         goto error;
     }
 
-    aid = malloc(sizeof(*aid));
+    aid = calloc(1, sizeof(*aid));
     if (aid == NULL) goto error;
 
     aid->do_null_io_write
@@ -208,19 +208,18 @@ abt_io_instance_id abt_io_init_pool(ABT_pool progress_pool)
 
 void abt_io_finalize(abt_io_instance_id aid)
 {
-    teardown_pool(aid);
-    json_object_put(aid->json_cfg);
 #ifdef USE_LIBURING
     if (aid->engine_type == ABT_IO_ENGINE_LIBURING) {
-        /* get completion queue fn to stop */
+        /* stop the persistent completion queue fn */
         aid->uring_shutdown_flag = 1;
         ABT_task_join(aid->uring_completion_task);
 
         /* tear down uring queues */
-        if (aid->engine_type == ABT_IO_ENGINE_LIBURING)
-            io_uring_queue_exit(&aid->ring);
+        io_uring_queue_exit(&aid->ring);
     }
 #endif
+    teardown_pool(aid);
+    json_object_put(aid->json_cfg);
     free(aid);
 }
 
@@ -244,17 +243,28 @@ struct abt_io_open_state {
     abt_io_instance_id aid;
 };
 
+#ifdef USE_LIBURING
 static void uring_completion_task_fn(void* foo)
 {
     struct abt_io_instance* aid = foo;
+    int                     ret;
+    struct io_uring_cqe*    cqe;
 
     while (!aid->uring_shutdown_flag) {
-        /* TODO: actual completion queue timed wait logic */
-        sleep(1);
+        /* NOTE: we intentionally do not user a timeout here.  If we need
+         * to break out of this call then we will issue a timeout op from
+         * another caller.
+         */
+        ret = io_uring_wait_cqe(&aid->ring, &cqe);
+        if (ret == 0) {
+            fprintf(stderr, "DBG: got cqe.\n");
+            io_uring_cqe_seen(&aid->ring, cqe);
+        }
     }
 
     return;
 }
+#endif
 
 static void abt_io_open_fn(void* foo)
 {

--- a/src/abt-io.c
+++ b/src/abt-io.c
@@ -291,12 +291,14 @@ static void uring_completion_task_fn(void* foo)
          */
         ret = io_uring_wait_cqe(&aid->ring, &cqe);
         if (ret == 0) {
-            if (!cqe->user_data) {
-                fprintf(stderr, "DBG: got cqe timeout break.\n");
-            } else {
-                fprintf(stderr, "DBG: got cqe (unknown).\n");
+            /* NOTE: if user_data isn't set, then we assume that it was just
+             * an event (e.g., a timeout) injected to break out of the wait
+             * call.
+             */
+            if (cqe->user_data) {
                 op = (struct abt_io_op*)cqe->user_data;
-                /* TODO: check for any type problems on supported ops */
+                /* TODO: will this casting work for the return type on all
+                 * supported operations? */
                 int64_t* result = op->state;
                 *result         = cqe->res;
                 ABT_eventual_set(op->e, NULL, 0);

--- a/tests/Makefile.subdir
+++ b/tests/Makefile.subdir
@@ -1,6 +1,7 @@
 EXTRA_DIST += \
- tests/concurrent-write-bench.sh\\
- tests/abt-io-benchmark.sh
+ tests/concurrent-write-bench.sh\
+ tests/abt-io-benchmark.sh\
+ tests/basic-uring.sh
 
 check_PROGRAMS += \
  tests/basic\
@@ -15,3 +16,6 @@ TESTS += \
  tests/abt-io-test-init-ext\
  tests/abt-io-benchmark.sh
 
+if BUILD_LIBURING
+ TESTS += tests/basic-uring.sh
+endif

--- a/tests/basic-uring.sh
+++ b/tests/basic-uring.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x
+
+echo "{\"engine\":\"liburing\"}" > /tmp/basic-liburing-$$.json
+
+tests/basic /tmp/basic-liburing-$$.json
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+exit 0

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -69,8 +69,10 @@ int main(int argc, char** argv)
     /* start up abt-io */
     if (args.json_config == NULL)
         aid = abt_io_init(2);
-    else
+    else {
         aid = abt_io_init_ext(&args);
+        free((char*)args.json_config);
+    }
 
     assert(aid != NULL);
 

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -51,6 +51,7 @@ int main(int argc, char** argv)
     abt_io_instance_id aid;
     struct abt_io_init_info args = { 0 };
     int                fd;
+    int                fd2;
     char template[64];
 
     ABT_init(argc, argv);
@@ -82,6 +83,10 @@ int main(int argc, char** argv)
 
     ret = abt_io_pwrite(aid, fd, &fd, sizeof(fd), 0);
     assert(ret == sizeof(fd));
+
+    ret = abt_io_pread(aid, fd, &fd2, sizeof(fd2), 0);
+    assert(ret == sizeof(fd2));
+    assert(fd == fd2);
 
     ret = abt_io_fallocate(aid, fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
                            sizeof(fd), sizeof(fd));


### PR DESCRIPTION
Fixes #19 

Enable with --enable-liburing at configure time and "engine":"liburing" in the json configuration at runtime.

One ES of the pool is dedicated to running a persistent task that waits for uring completion queue events.  The remaining ESes remain as is to service tasks that are not handled by liburing.

Initial quick implementation just replace the pwrite() path for evaluation purposes.  