### PR TITLE
Some fixes to make ABT-IO work on MacOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,11 +30,12 @@ AC_REQUIRE_CPP
 
 AC_CHECK_SIZEOF([long int])
 
-AC_MSG_CHECKING([for openssl])
-AX_CHECK_OPENSSL(
-AC_MSG_RESULT(yes)
-,
-AC_MSG_ERROR([Could not find openssl]))
+PKG_CHECK_MODULES([OPENSSL],[openssl],[],
+   [AC_MSG_ERROR([Could not find openssl])])
+LIBS="$OPENSSL_LIBS $LIBS"
+CPPFLAGS="$OPENSSL_CFLAGS $CPPFLAGS"
+CFLAGS="$OPENSSL_CFLAGS $CFLAGS"
+
 
 dnl
 dnl Verify pkg-config
@@ -79,7 +80,7 @@ CPPFLAGS="$JSONC_CFLAGS $CPPFLAGS"
 CFLAGS="$JSONC_CFLAGS $CFLAGS"
 
 AC_MSG_CHECKING([for fallocate])
-AC_TRY_COMPILE([
+AC_TRY_LINK([
 #define _GNU_SOURCE
 #include <fcntl.h>
 ], [

--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,7 @@ int ret = fallocate(0, 0, 0, 0);
 ],
 AC_MSG_RESULT(yes)
 AC_DEFINE([HAVE_FALLOCATE], [], [Define if fallocate available])
+CFLAGS="-D_GNU_SOURCE $CFLAGS"
 ,
 AC_MSG_RESULT(no))
 
@@ -119,6 +120,7 @@ int fd = mkostemp(NULL, 0);
 ], 
 AC_MSG_RESULT(yes)
 AC_DEFINE([HAVE_MKOSTEMP], [], [Define if mkostemp available])
+CFLAGS="-D_GNU_SOURCE $CFLAGS"
 ,
 NONCOMPLIANT_IO=1
 AC_MSG_RESULT(no))

--- a/examples/abt-io-benchmark.c
+++ b/examples/abt-io-benchmark.c
@@ -4,6 +4,17 @@
  * See COPYRIGHT in top-level directory.
  */
 
+#if __linux__
+#include <linux/version.h>
+#if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,22)
+#define _MAP_POPULATE_AVAILABLE
+#endif
+#endif
+
+#ifndef _MAP_POPULATE_AVAILABLE
+#define MAP_POPULATE MAP_PRIVATE
+#endif
+
 #define _GNU_SOURCE
 #include "abt-io-config.h"
 

--- a/examples/abt-io-benchmark.c
+++ b/examples/abt-io-benchmark.c
@@ -15,7 +15,6 @@
 #define MAP_POPULATE MAP_PRIVATE
 #endif
 
-#define _GNU_SOURCE
 #include "abt-io-config.h"
 
 #include <unistd.h>

--- a/examples/abt-io-overlap.c
+++ b/examples/abt-io-overlap.c
@@ -1,5 +1,3 @@
-#define _GNU_SOURCE
-
 #include <stdio.h>
 #include <assert.h>
 #include <unistd.h>

--- a/examples/concurrent-write-bench.c
+++ b/examples/concurrent-write-bench.c
@@ -1,5 +1,3 @@
-#define _GNU_SOURCE
-
 #include <stdio.h>
 #include <assert.h>
 #include <unistd.h>

--- a/examples/pthread-overlap.c
+++ b/examples/pthread-overlap.c
@@ -1,5 +1,3 @@
-#define _GNU_SOURCE
-
 #include <stdio.h>
 #include <assert.h>
 #include <unistd.h>

--- a/include/abt-io.h
+++ b/include/abt-io.h
@@ -13,10 +13,14 @@ extern "C" {
 
 #include <abt.h>
 #include <sys/types.h>
+#if defined(__APPLE__)
+#include <sys/mount.h>
+#else
 #include <sys/vfs.h>
+#endif
 #include <stdlib.h>
 
-#define DEPRECATED(msg) __attribute__((deprecated(msg)))
+#define ABT_IO_DEPRECATED(msg) __attribute__((deprecated(msg)))
 
 struct abt_io_instance;
 typedef struct abt_io_instance* abt_io_instance_id;
@@ -91,7 +95,7 @@ abt_io_instance_id abt_io_init_ext(const struct abt_io_init_info* args);
  * @returns abt_io instance id on success, NULL upon error
  */
 abt_io_instance_id abt_io_init_pool(ABT_pool progress_pool)
-    DEPRECATED("use abt_io_init_ext instead");
+    ABT_IO_DEPRECATED("use abt_io_init_ext instead");
 
 /**
  * Shuts down abt_io library and its underlying resources. Waits for underlying

--- a/include/abt-io.h
+++ b/include/abt-io.h
@@ -14,9 +14,9 @@ extern "C" {
 #include <abt.h>
 #include <sys/types.h>
 #if defined(__APPLE__)
-#include <sys/mount.h>
+    #include <sys/mount.h>
 #else
-#include <sys/vfs.h>
+    #include <sys/vfs.h>
 #endif
 #include <stdlib.h>
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,7 @@ spack:
   - libtool
   - pkg-config
   - argobots
+  - openssl
   concretizer:
     unify: true
     reuse: true

--- a/src/abt-io.c
+++ b/src/abt-io.c
@@ -18,7 +18,6 @@
 #else
     #include <sys/vfs.h>
 #endif
-#define _GNU_SOURCE
 #include <fcntl.h>
 #include <json-c/json.h>
 

--- a/src/abt-io.c
+++ b/src/abt-io.c
@@ -6,7 +6,6 @@
 
 #include "abt-io-config.h"
 
-#define _GNU_SOURCE
 
 #include <assert.h>
 #include <unistd.h>
@@ -15,7 +14,12 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#if defined(__APPLE__)
+#include <sys/mount.h>
+#else
 #include <sys/vfs.h>
+#endif
+#define _GNU_SOURCE
 #include <fcntl.h>
 #include <json-c/json.h>
 

--- a/src/abt-io.c
+++ b/src/abt-io.c
@@ -6,7 +6,6 @@
 
 #include "abt-io-config.h"
 
-
 #include <assert.h>
 #include <unistd.h>
 #include <errno.h>
@@ -15,9 +14,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #if defined(__APPLE__)
-#include <sys/mount.h>
+    #include <sys/mount.h>
 #else
-#include <sys/vfs.h>
+    #include <sys/vfs.h>
 #endif
 #define _GNU_SOURCE
 #include <fcntl.h>

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -9,13 +9,14 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/statfs.h>
+//#include <sys/statfs.h>
 #include <fcntl.h>
 #include <float.h>
 #include <errno.h>
 
 #include <abt.h>
 #include <abt-io.h>
+#include <abt-io-config.h>
 
 char* readfile(const char* filename) {
     FILE *f = fopen(filename, "r");
@@ -81,9 +82,11 @@ int main(int argc, char** argv)
     ret = abt_io_pwrite(aid, fd, &fd, sizeof(fd), 0);
     assert(ret == sizeof(fd));
 
+#if HAVE_FALLOCATE
     ret = abt_io_fallocate(aid, fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
                            sizeof(fd), sizeof(fd));
     assert(ret == 0);
+#endif
 
     ret = abt_io_truncate(aid, template, 1024);
     assert(ret == 0);

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -82,7 +82,7 @@ int main(int argc, char** argv)
     ret = abt_io_pwrite(aid, fd, &fd, sizeof(fd), 0);
     assert(ret == sizeof(fd));
 
-#if HAVE_FALLOCATE
+#ifdef HAVE_FALLOCATE
     ret = abt_io_fallocate(aid, fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
                            sizeof(fd), sizeof(fd));
     assert(ret == 0);

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -1,5 +1,3 @@
-#define _GNU_SOURCE
-
 #include <stdio.h>
 #include <assert.h>
 #include <unistd.h>


### PR DESCRIPTION
This PR fixes build issues on MacOS. This was tried on a MacBook Pro M2 with gcc 13.
The PR changes the following things:
- Use `PKG_CHECK_MODULES` for finding OpenSSL instead of `AX_CHECK_OPENSSL` (for some reason the latter doesn't work on Mac, but since OpenSSL provides a .pc file, we can just use that). By the way this OpenSSL dependency really ought to be removed...
- `AC_TRY_LINK` instead of `AC_TRY_COMPILE` for testing whether `fallocate` is available (other it finds it to be available when it's not).
- Define `MAP_POPULATE` as `MAP_PRIVATE` if it's not define (Mac doesn't have it).
- Use `sys/mount.h` instead of `sys/vfs.h` on Mac.
- Commented the use of `sys/statfs.h` (doesn't exist on Mac, we will see if it's needed by Linux when the unit tests run).
- Check `HAVE_FALLOCATE` before calling `abt_io_fallocate` in test.